### PR TITLE
fix(accordion): prefix node.identifier with a string 'accordionitem' …

### DIFF
--- a/Resources/Private/Templates/FusionObjects/AccordionItem.html
+++ b/Resources/Private/Templates/FusionObjects/AccordionItem.html
@@ -3,12 +3,12 @@
 <div class="card">
     <div class="card-header" role="tab" id="heading{node.identifier}">
         <h5 class="mb-0">
-            <a data-toggle="collapse" href="#{node.identifier}" aria-expanded="true" aria-controls="{node.identifier}">
+            <a data-toggle="collapse" href="#accordionitem{node.identifier}" aria-expanded="true" aria-controls="accordionitem{node.identifier}">
                 {neos:contentElement.editable(property: 'title', tag: 'span')}
             </a>
         </h5>
     </div>
-    <div id="{node.identifier}" class="collapse" role="tabpanel" aria-labelledby="heading{node.identifier}">
+    <div id="accordionitem{node.identifier}" class="collapse" role="tabpanel" aria-labelledby="heading{node.identifier}">
         <div class="card-body">
             {accordionItems -> f:format.raw()}
         </div>


### PR DESCRIPTION
…to prevent using id="" starting with a number

HTML Elements can't have id's which starts with a number. If using node.identifier (it's a hex guid) as the id attribute, it can happen that the accordionItem isn't able to toggle the collapse state.

This commit prefixes the id attribute with a string 'accordionitem' to prevent this issue.